### PR TITLE
Remove "View my work" button from Profile

### DIFF
--- a/Components/Profile.js
+++ b/Components/Profile.js
@@ -83,9 +83,6 @@ export default class Profile extends Component {
             ends backed by Node, ASP.NET, or Java Spring Boot. Comfortable
             across the stack, I focus on clean code and dependable delivery.
           </p>
-          <a className="cta" href="#projects">
-            View my work
-          </a>
         </div>
       </ProfileContainer>
     );


### PR DESCRIPTION
## Summary
- Removes the "View my work" CTA button (`<a className="cta" href="#projects">`) from the Profile hero section.

## Verification
- `git diff` confirms the only change is the deletion of the 3-line `<a>` element in `Components/Profile.js`; no other markup, styling, or content was altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)